### PR TITLE
Improve security

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,18 @@ end
 When using the `magic_url_for` helper you'll need to specify default_url_options for your development and testing
 environments.
 
+### Magic token cookie expiry
+A magic token cookie is dropped on the client when a magic link is used. This cookie is used to authenticate subsequent 
+requests. By default, the magic token cookie expiry (not to be confused with the expiry of the magic link) is set to 
+1 hour. You can override this setting by setting it in an initializer:
+
+```ruby
+# in /config/initializers/magic_links.rb
+
+MagicLinks.magic_token_cookie_expiry = 15.minutes
+```
+
+By setting a short expiry it reduces security risks on shared devices.
+
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/magic_links.rb
+++ b/lib/magic_links.rb
@@ -6,6 +6,8 @@ require 'magic_links/strategies/magic_token_authentication'
 require 'magic_links/rails'
 
 module MagicLinks
+  mattr_accessor :magic_token_cookie_expiry, default: 1.hour
+
   def self.add_template(*args)
     MagicLinks::Templates.add(*args)
   end

--- a/lib/magic_links/middleware/magic_token_redirect.rb
+++ b/lib/magic_links/middleware/magic_token_redirect.rb
@@ -22,7 +22,7 @@ module MagicLinks
           return unless redirect_request?
           return root unless magic_token.present?
 
-          cookies.encrypted[magic_token_key] = magic_token.token if scope
+          cookies.encrypted[magic_token_key] = {value: magic_token.token, expires: cookie_expiry} if scope
           respond_with_redirect magic_token.target_path
         end
 
@@ -71,6 +71,10 @@ module MagicLinks
 
         def cookies
           request.cookie_jar
+        end
+
+        def cookie_expiry
+          MagicLinks.magic_token_cookie_expiry
         end
       end
     end

--- a/lib/magic_links/middleware/magic_token_redirect.rb
+++ b/lib/magic_links/middleware/magic_token_redirect.rb
@@ -22,7 +22,7 @@ module MagicLinks
           return unless redirect_request?
           return root unless magic_token.present?
 
-          cookies.signed[magic_token_key] = magic_token.token if scope
+          cookies.encrypted[magic_token_key] = magic_token.token if scope
           respond_with_redirect magic_token.target_path
         end
 

--- a/lib/magic_links/strategies/magic_token_authentication.rb
+++ b/lib/magic_links/strategies/magic_token_authentication.rb
@@ -55,7 +55,7 @@ module MagicLinks
       end
 
       def magic_token_cookie
-        @magic_token_cookie ||= cookies.signed[magic_token_key]
+        @magic_token_cookie ||= cookies.encrypted[magic_token_key]
       end
 
       def controller

--- a/lib/magic_links/version.rb
+++ b/lib/magic_links/version.rb
@@ -1,5 +1,5 @@
 module MagicLinks
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 
   def self.version
     VERSION

--- a/spec/lib/middleware/magic_token_redirect_spec.rb
+++ b/spec/lib/middleware/magic_token_redirect_spec.rb
@@ -27,12 +27,12 @@ describe MagicLinks::Middleware::MagicTokenRedirect do
       expect(response.header['Location']).to eq magic_token.target_path
     end
 
-    it 'sets the token as a signed cookie for the given scope' do
+    it 'sets the token as an encrypted cookie for the given scope' do
       # the cookie itself is written by ActionDispatch::Cookies middleware
       # which acts on the response after MagicTokenRedirect.
       # Therefore we need only test that our middleware sets the cookie via ActionDispatch
       Rack::MockResponse.new(*subject.call(request.env))
-      expect(request.cookie_jar.signed[:user_magic_token]).to eq magic_token.token
+      expect(request.cookie_jar.encrypted[:user_magic_token]).to eq magic_token.token
     end
 
     context 'when the authenticatable target no longer exists' do

--- a/spec/lib/strategies/magic_token_athentication_spec.rb
+++ b/spec/lib/strategies/magic_token_athentication_spec.rb
@@ -24,7 +24,7 @@ describe MagicLinks::Strategies::MagicTokenAuthentication do
       it { is_expected.not_to be_valid }
 
       context 'when there is a cookie for the requested scope' do
-        before { request.cookie_jar.signed["#{magic_token.scope}_magic_token"] = magic_token.token }
+        before { request.cookie_jar.encrypted["#{magic_token.scope}_magic_token"] = magic_token.token }
 
         it { is_expected.to be_valid }
       end
@@ -32,7 +32,7 @@ describe MagicLinks::Strategies::MagicTokenAuthentication do
   end
 
   describe '#authenticate!' do
-    before { request.cookie_jar.signed["#{magic_token.scope}_magic_token"] = magic_token.token }
+    before { request.cookie_jar.encrypted["#{magic_token.scope}_magic_token"] = magic_token.token }
 
     context 'when all is correct' do
       it 'succeeds with the authenticatable scope' do
@@ -52,7 +52,7 @@ describe MagicLinks::Strategies::MagicTokenAuthentication do
     end
 
     context 'when the magic token does not exist' do
-      before { request.cookie_jar.signed["#{magic_token.scope}_magic_token"] = SecureRandom.urlsafe_base64(8) }
+      before { request.cookie_jar.encrypted["#{magic_token.scope}_magic_token"] = SecureRandom.urlsafe_base64(8) }
 
       it 'does not authenticate' do
         expect(subject).not_to receive(:success!)


### PR DESCRIPTION
* set default magic token cookie expiry to 1 hour (can be overridden)
* use `cookies.encrypted` instead of `cookies.signed` so cookie cannot be read