### PR TITLE
Adds to_prepare block to Railtie Initializer

### DIFF
--- a/lib/magic_links/rails.rb
+++ b/lib/magic_links/rails.rb
@@ -2,9 +2,11 @@ module MagicLinks
   class Engine < ::Rails::Engine
 
     initializer 'magic_links.url_helpers' do
-      ActiveSupport.on_load(:action_controller) do
-        include MagicLinks::UrlHelper
-      end
+      Rails.application.reloader.to_prepare do
+        ActiveSupport.on_load(:action_controller) do
+          include MagicLinks::UrlHelper
+        end
+      end  
     end
 
     initializer 'magic_links.middleware_redirect', before: :build_middleware_stack do |app|


### PR DESCRIPTION
Fixes #10 

The initializer was including the MagicLinks::UrlHelper into ActionController. However, the UrlHelper file is automatically added to the 'hot reloading' list. If the class was updated, the initializer would not be re-run and the included version of UrlHelper would be stale. This was raising the following deprecation warning:

`DEPRECATION WARNING: Initialization autoloaded the constant MagicLinks::UrlHelper.`

I've wrapped the initializer in a `to_prepare` block, so that it get's rerun when the rails application undergoes a 'hot reload'