### PR TITLE
[Fix] Named params forwarding bug at init

### DIFF
--- a/lib/magic_links.rb
+++ b/lib/magic_links.rb
@@ -8,7 +8,7 @@ require 'magic_links/rails'
 module MagicLinks
   mattr_accessor :magic_token_cookie_expiry, default: 1.hour
 
-  def self.add_template(*args)
-    MagicLinks::Templates.add(*args)
+  def self.add_template(args)
+    MagicLinks::Templates.add(**args)
   end
 end


### PR DESCRIPTION
There is a bug, that instead of expanding the named params, forwards them as a hash.
That, of course, throws an error while running the `magic_links.rb` initializer.

This PR aims to fix that.
___
Alternate syntax using the [shorthand syntax for arguments forwarding added](https://blog.saeloun.com/2019/12/04/ruby-2-7-adds-new-operator-for-arguments-forwarding.html) in Ruby@2.7 would be;

```ruby
def self.add_template(...)
  MagicLinks::Templates.add(...)
end
```

Let me know if you guys would like me to update it using the syntax mentioned above.